### PR TITLE
Verify that Rx.Observable's implementation of Enumerable.to_list/1 crashes …

### DIFF
--- a/test/rx/observable_test.exs
+++ b/test/rx/observable_test.exs
@@ -21,14 +21,13 @@ defmodule Rx.ObservableTest do
     end
   end
 
+  @crash_observable %Rx.Observable{reversed_stages: [%CrashStage{}]}
+
   describe "to_list/1 (via Enumerable)" do
     test "crashes if source stream crashes on construction" do
       capture_log(fn ->
-        assert {:bogus, _} = catch_exit(
-          Enum.to_list(Rx.Observable.create(fn _next ->
-            exit(:bogus)
-          end))
-        )
+        assert {{%RuntimeError{message: "test failure in init fn"}, _}, _} =
+          catch_exit(Enum.to_list(@crash_observable))
       end)
     end
   end

--- a/test/rx/observable_test.exs
+++ b/test/rx/observable_test.exs
@@ -25,10 +25,9 @@ defmodule Rx.ObservableTest do
     test "crashes if source stream crashes on construction" do
       capture_log(fn ->
         assert {:bogus, _} = catch_exit(
-          o = Rx.Observable.create(fn _next ->
+          Enum.to_list(Rx.Observable.create(fn _next ->
             exit(:bogus)
-          end)
-          Enum.to_list(o)
+          end))
         )
       end)
     end

--- a/test/rx/observable_test.exs
+++ b/test/rx/observable_test.exs
@@ -3,6 +3,8 @@ defmodule Rx.ObservableTest do
 
   doctest Rx.Observable
 
+  import ExUnit.CaptureLog
+
   @empty_observable %Rx.Observable{} # not a supported use case!
 
   describe "add_stage/3 (internal)" do
@@ -16,6 +18,19 @@ defmodule Rx.ObservableTest do
       assert_raise RuntimeError, fn ->
         Rx.Observable.to_notifications("not an Observable")
       end
+    end
+  end
+
+  describe "to_list/1 (via Enumerable)" do
+    test "crashes if source stream crashes on construction" do
+      capture_log(fn ->
+        assert {:bogus, _} = catch_exit(
+          Rx.Observable.create(fn _next ->
+            exit(:bogus)
+          end)
+          |> Enum.to_list()
+        )
+      end)
     end
   end
 end

--- a/test/rx/observable_test.exs
+++ b/test/rx/observable_test.exs
@@ -25,10 +25,10 @@ defmodule Rx.ObservableTest do
     test "crashes if source stream crashes on construction" do
       capture_log(fn ->
         assert {:bogus, _} = catch_exit(
-          Rx.Observable.create(fn _next ->
+          o = Rx.Observable.create(fn _next ->
             exit(:bogus)
           end)
-          |> Enum.to_list()
+          Enum.to_list(o)
         )
       end)
     end

--- a/test/support/crash_stage.ex
+++ b/test/support/crash_stage.ex
@@ -1,0 +1,15 @@
+defmodule CrashStage do
+  @moduledoc false  # internal
+
+  use GenStage
+
+  defstruct fun: nil
+
+  def start(%__MODULE__{}, :producer, options \\ []) do
+    GenStage.start(__MODULE__, {nil, :producer}, options)
+  end
+
+  def init({_nil, :producer}) do
+    raise "test failure in init fn"
+  end
+end


### PR DESCRIPTION
… if source Observable crashes.