### PR TITLE
Introduce Rx.Error which is how we should normally communicate the Rx error status.

### DIFF
--- a/lib/rx/error.ex
+++ b/lib/rx/error.ex
@@ -1,0 +1,12 @@
+defmodule Rx.Error do
+  @moduledoc ~S"""
+  This error should be raised to signal an error exit from any Observable.
+
+  Rx code will strip away the exception code and pass simply the `message`
+  value in any error tuple reported.
+
+  Any *other* exception that is raised will be passed through as is.
+  """
+
+  defexception message: "No error message provided."
+end

--- a/lib/rx/observable.ex
+++ b/lib/rx/observable.ex
@@ -65,7 +65,16 @@ defmodule Rx.Observable do
     iex> Rx.Observable.create(fn next ->
     ...>   next.("Hello")
     ...>   next.("World")
-    ...>   raise "foo"
+    ...>   raise Rx.Error, message: "foo"
+    ...> end)
+    ...> |> Rx.Observable.to_notifications()
+    ...> |> Enum.to_list()
+    [{:next, "Hello"}, {:next, "World"}, {:error, "foo"}]
+
+    iex> Rx.Observable.create(fn next ->
+    ...>   next.("Hello")
+    ...>   next.("World")
+    ...>   raise "foo"  # raises RuntimeError instead
     ...> end)
     ...> |> Rx.Observable.to_notifications()
     ...> |> Enum.to_list()

--- a/lib/rx/observable/to_notifications_stage.ex
+++ b/lib/rx/observable/to_notifications_stage.ex
@@ -5,49 +5,39 @@ defmodule Rx.Observable.ToNotificationsStage do
 
   defstruct placeholder: nil
 
-  def start(%__MODULE__{}, type, options \\ []) do
+  def start(%__MODULE__{}, type, options \\ []), do:
     GenStage.start(__MODULE__, type, options)
-  end
 
-  def init(type) do
-    {type, :no_state}
-  end
+  def init(type), do:
+    {type, :not_yet_subscribed}
 
-  def handle_subscribe(_type, _options, subscriber, _state) do
+  def handle_subscribe(_type, _options, subscriber, _state), do:
     {:automatic, subscriber}
-  end
 
-  def handle_events(events, _from, state) do
+  def handle_events(events, _from, state), do:
     {:noreply, Enum.map(events, &({:next, &1})), state}
-  end
 
-  def handle_cancel({:cancel, _reason}, _from, state) do
-    {:stop, :normal, state}
-  end
+  def handle_cancel({:cancel, reason}, _from, state), do:
+    send_termination(reason, state)
+  def handle_cancel({:down, :normal}, _from, state), do:
+    send_termination(:normal, state)
+  def handle_cancel({:down, {:shutdown, reason}}, _from, state), do:
+    send_termination(reason, state)
+  def handle_cancel({:down, reason}, _from, state), do:
+    send_termination(reason, state)
 
-  def handle_cancel({:down, :normal}, _from, state) do
-    send(self(), :send_stop)
-    {:noreply, [:done], state}
-  end
-
-  def handle_cancel({:down, {:shutdown, reason}}, _from, {pid, refs} = subscriber) do
-    Process.send(pid, {:"$gen_consumer", {self(), refs}, [{:error, reason}]},
-                 [:noconnect])
-    {:stop, :normal, subscriber}
-  end
-
-  def handle_cancel({:down, reason}, _from, {pid, refs} = subscriber) do
-    Process.send(pid, {:"$gen_consumer", {self(), refs}, [{:error, reason}]},
-                 [:noconnect])
-    {:stop, :normal, subscriber}
-  end
-
-  def handle_info(:send_stop, state) do
-    {:stop, :normal, state}
-  end
-
-  def handle_info({:stop, _reason}, state) do
+  def handle_info({:stop, _reason}, state), do:
     {:stop, :normal, state}
       # Intentionally converting upstream error to :normal stop here.
+
+  defp send_termination(reason, {pid, refs} = subscriber) do
+    Process.send(pid,
+                 {:"$gen_consumer", {self(), refs}, [translate_reason(reason)]},
+                 [:noconnect])
+    {:stop, :normal, subscriber}
   end
+
+  defp translate_reason(:normal), do: :done
+  defp translate_reason(%Rx.Error{message: message}), do: {:error, message}
+  defp translate_reason(reason), do: {:error, reason}
 end


### PR DESCRIPTION
Refactor how Rx.Observable.ToNotificationsStage is built to accommodate this change.