### PR TITLE
Drop support for Elixir 1.3.x.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,17 @@
 language: elixir
 
 elixir:
-  - 1.3.4
   - 1.4.4
   - 1.5.1
 
 otp_release:
-  - 18.0
   - 19.3
   - 20.0
 
 matrix:
   exclude:
-  - elixir: 1.3.4
-    otp_release: 19.3
-  - elixir: 1.3.4
-    otp_release: 20.0
   - elixir: 1.4.4
     otp_release: 20.0
-  - elixir: 1.5.1
-    otp_release: 18.0
 
 script:
   - mix deps.get

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Rx.Mixfile do
     [app: :rx,
      version: "0.1.0",
      name: "Rx",
-     elixir: "~> 1.3.4 or ~> 1.4",
+     elixir: "~> 1.4",
      elixirc_options: [warnings_as_errors: true],
      deps: deps(),
      elixirc_paths: elixirc_paths(Mix.env),


### PR DESCRIPTION
By the time this library gets to a public release, that shouldn't be an issue IMHO.