### PR TITLE
Simplify VirtualTimeScheduler interface.

### DIFF
--- a/test/rx/internal/virtual_time_scheduler_test.exs
+++ b/test/rx/internal/virtual_time_scheduler_test.exs
@@ -57,7 +57,7 @@ defmodule VirtualTimeSchedulerTest do
                          {700, reverse, :ignore}]}
     end
 
-    assert init |> VTS.run(nil, []) ==
+    assert VTS.run(init, nil, []) ==
       [{0, 1}, {0, 3}, {0, 5}, {100, 2}, {100, 6}, {500, 4}]
   end
 

--- a/test/rx/internal/virtual_time_scheduler_test.exs
+++ b/test/rx/internal/virtual_time_scheduler_test.exs
@@ -26,11 +26,11 @@ defmodule VirtualTimeSchedulerTest do
     end
 
     init = fn(0, nil, acc) ->
-      {acc, new_events: [{  0, invoke, 1},
+      {acc, new_events: [{0, invoke, 1},
                          {100, invoke, 2},
-                         {  0, invoke, 3},
+                         {0, invoke, 3},
                          {500, invoke, 4},
-                         {  0, invoke, 5},
+                         {0, invoke, 5},
                          {100, invoke, 6}]}
     end
 
@@ -48,11 +48,11 @@ defmodule VirtualTimeSchedulerTest do
     end
 
     init = fn(0, nil, acc) ->
-      {acc, new_events: [{  0, invoke, 1},
+      {acc, new_events: [{0, invoke, 1},
                          {100, invoke, 2},
-                         {  0, invoke, 3},
+                         {0, invoke, 3},
                          {500, invoke, 4},
-                         {  0, invoke, 5},
+                         {0, invoke, 5},
                          {100, invoke, 6},
                          {700, reverse, :ignore}]}
     end

--- a/test/rx/internal/virtual_time_scheduler_test.exs
+++ b/test/rx/internal/virtual_time_scheduler_test.exs
@@ -16,7 +16,7 @@ defmodule VirtualTimeSchedulerTest do
                          {0, invoke, 5}]}
     end
 
-    assert VTS.run(init, nil, []) |> Enum.reverse() ==
+    assert init |> VTS.run(nil, []) |> Enum.reverse() ==
       [{0, 1}, {0, 2}, {0, 3}, {0, 4}, {0, 5}]
   end
 
@@ -34,7 +34,7 @@ defmodule VirtualTimeSchedulerTest do
                          {100, invoke, 6}]}
     end
 
-    assert VTS.run(init, nil, []) |> Enum.reverse() ==
+    assert init |> VTS.run(nil, []) |> Enum.reverse() ==
       [{0, 1}, {0, 3}, {0, 5}, {100, 2}, {100, 6}, {500, 4}]
   end
 
@@ -57,7 +57,7 @@ defmodule VirtualTimeSchedulerTest do
                          {700, reverse, :ignore}]}
     end
 
-    assert VTS.run(init, nil, []) ==
+    assert init |> VTS.run(nil, []) ==
       [{0, 1}, {0, 3}, {0, 5}, {100, 2}, {100, 6}, {500, 4}]
   end
 
@@ -79,7 +79,7 @@ defmodule VirtualTimeSchedulerTest do
   end
 
   test "can schedule new events at same 'time' while running" do
-    assert VTS.run(&recursive_invoke/3, 1, []) |> Enum.reverse() ==
+    assert &recursive_invoke/3 |> VTS.run(1, []) |> Enum.reverse() ==
       [{0, 1}, {0, 2}, {0, 3}, {0, 4}]
   end
 
@@ -89,7 +89,7 @@ defmodule VirtualTimeSchedulerTest do
   end
 
   test "can schedule new events at later 'time' while running" do
-    assert VTS.run(&recursive_invoke_with_delay/3, 1, []) |> Enum.reverse() ==
+    assert &recursive_invoke_with_delay/3 |> VTS.run(1, []) |> Enum.reverse() ==
       [{0, 1}, {10, 2}, {20, 3}, {30, 4}]
   end
 end

--- a/test/rx/internal/virtual_time_scheduler_test.exs
+++ b/test/rx/internal/virtual_time_scheduler_test.exs
@@ -79,7 +79,7 @@ defmodule VirtualTimeSchedulerTest do
   end
 
   test "can schedule new events at same 'time' while running" do
-    assert &recursive_invoke/3 |> VTS.run(1, []) |> Enum.reverse() ==
+    assert Enum.reverse(VTS.run(&recursive_invoke/3, 1, [])) ==
       [{0, 1}, {0, 2}, {0, 3}, {0, 4}]
   end
 
@@ -89,7 +89,7 @@ defmodule VirtualTimeSchedulerTest do
   end
 
   test "can schedule new events at later 'time' while running" do
-    assert &recursive_invoke_with_delay/3 |> VTS.run(1, []) |> Enum.reverse() ==
+    assert Enum.reverse(VTS.run(&recursive_invoke_with_delay/3, 1, [])) ==
       [{0, 1}, {10, 2}, {20, 3}, {30, 4}]
   end
 end


### PR DESCRIPTION
There is now a single public entry point; everything is communicated to it via optional return values.